### PR TITLE
Php73 compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PDFMerger for PHP (PHP 5 amd 7 Compatible)
+# PDFMerger for PHP (PHP 5 and 7 Compatible)
 
 Original written by http://pdfmerger.codeplex.com/team/view<br />
 Forked from https://github.com/hpolthof/pdf-merger which forked from https://github.com/clegginabox/pdf-merger which forked from https://github.com/myokyawhtun/PDFMerger

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "PDF File Merger for PHP 5 & 7, for usage with SetAsign FPDI.",
     "version": "2.0.0",
     "require": {
-        "setasign/fpdi-fpdf": "^2"
+        "setasign/fpdi-fpdf": "^2",
+        "tecnickcom/tcpdf": "^6.2.19"
     },
     "authors": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eda810cf44d8b6655c2a6d2ec15e2201",
+    "content-hash": "51360f28ff89f12c263bc145ee15817e",
     "packages": [
         {
             "name": "setasign/fpdf",
@@ -144,6 +144,68 @@
                 "pdf"
             ],
             "time": "2018-11-06T10:40:46+00:00"
+        },
+        {
+            "name": "tecnickcom/tcpdf",
+            "version": "6.2.26",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tecnickcom/TCPDF.git",
+                "reference": "367241059ca166e3a76490f4448c284e0a161f15"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/367241059ca166e3a76490f4448c284e0a161f15",
+                "reference": "367241059ca166e3a76490f4448c284e0a161f15",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "config",
+                    "include",
+                    "tcpdf.php",
+                    "tcpdf_parser.php",
+                    "tcpdf_import.php",
+                    "tcpdf_barcodes_1d.php",
+                    "tcpdf_barcodes_2d.php",
+                    "include/tcpdf_colors.php",
+                    "include/tcpdf_filters.php",
+                    "include/tcpdf_font_data.php",
+                    "include/tcpdf_fonts.php",
+                    "include/tcpdf_images.php",
+                    "include/tcpdf_static.php",
+                    "include/barcodes/datamatrix.php",
+                    "include/barcodes/pdf417.php",
+                    "include/barcodes/qrcode.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Nicola Asuni",
+                    "email": "info@tecnick.com",
+                    "role": "lead"
+                }
+            ],
+            "description": "TCPDF is a PHP class for generating PDF documents and barcodes.",
+            "homepage": "http://www.tcpdf.org/",
+            "keywords": [
+                "PDFD32000-2008",
+                "TCPDF",
+                "barcodes",
+                "datamatrix",
+                "pdf",
+                "pdf417",
+                "qrcode"
+            ],
+            "time": "2018-10-16T17:24:05+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
- Specifies the version of TCPDF to use - as there was a bug which threw warnings everywhere
in PHP 7.3